### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.plist linguist-detectable=true
+*.glyphs linguist-detectable=true
+*.glyph linguist-language=Glyph


### PR DESCRIPTION
B站粉丝一枚。对字体设计不是很了解，但你们应该是用 Glyphs 开发的吧？GitHub的repo的语言统计其实需要配置文件才能正确识别一些少见的语言。这个语音统计模块的官方源码仓库是 https://github.com/github/linguist

我以前就在别的项目上了解过了语言统计的配置方式。所以看到视频里说发布了源码、但是只显示了 HTML 的时候，就想到应该是需要配置，所以就来看看，没想到 GitHub 的语言库里还真录入了 Glyphs，只不过需要手动配置才能开启。

配置这个最主要的好处，是更利于项目宣传。高级搜索可以过滤仓库语言，而且别人看到这个仓库是 HTML 的话也会第一时间以为是静态网页。现在就不会啦。

现在：
![image](https://user-images.githubusercontent.com/75297777/201955803-039272fb-a8db-4589-bf7f-1e3e7e398018.png)

配置后（这个效果可以在我fork的仓库里看到）：
![image](https://user-images.githubusercontent.com/75297777/201955741-976fb2de-e5ab-45bd-9744-de1dd4d1e4bd.png)

其实 GitHub 的语言库里有三个类似的 tag，分别是 `OpenStep Property List`, `Glyph` 和 `Glyph Bitmap Distribution Format`。如果另外两种 tag 更合适，也可以让我改。