### PR TITLE
修正 macOS 安装命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
   - [macOS](https://support.apple.com/zh-cn/HT201749)
     - 也可使用 [Homebrew](https://brew.sh/index_zh-cn) 进行安装，在命令行中输入以下指令（这要求已经安装好 Homebrew）：
       ```bash
-      brew tap homebrew/cask-fonts  # 只需要在第一次安装时执行
       brew install font-smiley-sans
       ```
   - Linux


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5cf9d96b-2eec-4e7b-ad0f-b573eb84f93b)


homebrew-cask-fonts 已经 deprecated 了，所有的 fonts 都被移到了 cask 仓库，详见：

https://github.com/Homebrew/homebrew-cask-fonts